### PR TITLE
Deploy Command

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,9 +8,13 @@ gem "octokit"
 
 group :development, :test do
   gem "pry-byebug"
-  gem "rack-test"
   gem "rubocop", require: false
+end
+
+group :test do
+  gem "rack-test"
   gem "rspec"
+  gem "webmock"
 end
 
 group :deploy do

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem "activesupport", "~> 4", require: "active_support/all"
 gem "lita"
 gem "lita-slack"
 
-gem "ejson"
+gem "octokit"
 
 group :development, :test do
   gem "pry-byebug"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,6 +26,8 @@ GEM
     coderay (1.1.0)
     colorize (0.7.7)
     columnize (0.9.0)
+    crack (0.4.2)
+      safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
     ejson (1.0.0)
     eventmachine (1.0.7)
@@ -107,6 +109,7 @@ GEM
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.4)
     ruby-progressbar (1.7.5)
+    safe_yaml (1.0.4)
     sawyer (0.6.0)
       addressable (~> 2.3.5)
       faraday (~> 0.8, < 0.10)
@@ -121,6 +124,9 @@ GEM
       thread_safe (~> 0.1)
     url_mount (0.2.1)
       rack
+    webmock (1.21.0)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
     websocket-driver (0.6.2)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
@@ -140,6 +146,7 @@ DEPENDENCIES
   rack-test
   rspec
   rubocop
+  webmock
 
 BUNDLED WITH
    1.10.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    addressable (2.3.8)
     ast (2.0.0)
     astrolabe (1.3.1)
       parser (~> 2.2)
@@ -64,6 +65,8 @@ GEM
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (2.9.2)
+    octokit (4.0.1)
+      sawyer (~> 0.6.0, >= 0.5.3)
     parser (2.2.2.6)
       ast (>= 1.1, < 3.0)
     powerpack (0.1.1)
@@ -104,6 +107,9 @@ GEM
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.4)
     ruby-progressbar (1.7.5)
+    sawyer (0.6.0)
+      addressable (~> 2.3.5)
+      faraday (~> 0.8, < 0.10)
     slop (3.6.0)
     sshkit (1.7.1)
       colorize (>= 0.7.0)
@@ -127,9 +133,9 @@ DEPENDENCIES
   capistrano
   capistrano-bundler
   capistrano-ejson
-  ejson
   lita
   lita-slack
+  octokit
   pry-byebug
   rack-test
   rspec

--- a/config/secrets.production.ejson
+++ b/config/secrets.production.ejson
@@ -1,5 +1,8 @@
 {
   "_public_key": "b044cc90a6fd944394849f009ddefcfa243e58388fb669c52163f0208fc62040",
+  "octokit": {
+    "token": "EJ[1:LH2QQf2wDuj20LAj46qswtcDcxl2VIUNSMGcTxS28Tw=:jX8ZTJfGoYopF75GtTIma1jUuadsk4OO:JaEPjGt6wb1KmsCpl2kATwRExjTPlLtEcUz48uVUBvtlWxojsuRf2EvGsntnomEA8F5pEoWZyGc=]"
+  },
   "lita": {
     "robot": {
       "name": "EJ[1:yriKh8+VGoo3iIlWU98OvkCH2Ap38A7/QgAn1pkBeF8=:QDMqacuM+8LNZD7U/VER2W0tHG/XFvFm:zSitnp8k1a6xxtSB8lMrEeOdztc=]",

--- a/config/settings.example.yml
+++ b/config/settings.example.yml
@@ -1,12 +1,17 @@
 common: &common
-  robot:
-    name: dude
-    log_level: :info
-    adapter: :shell
+  octokit:
+    token: YOUR_GITHUB_TOKEN
+  lita:
+    robot:
+      name: dude
+      log_level: :info
+      adapter: :shell
 
 development:
   <<: *common
 
 test:
   <<: *common
-  name: test
+  lita:
+    robot:
+      name: test

--- a/lib/dude.rb
+++ b/lib/dude.rb
@@ -4,4 +4,5 @@ module Dude
 end
 # rubocop:enable Style/ClassAndModuleChildren
 
+Dir[File.expand_path("../dude/*.rb", __FILE__)].each { |file| require file }
 Dir[File.expand_path("../dude/handlers/*.rb", __FILE__)].each { |file| require file }

--- a/lib/dude.rb
+++ b/lib/dude.rb
@@ -4,4 +4,4 @@ module Dude
 end
 # rubocop:enable Style/ClassAndModuleChildren
 
-require_relative "dude/handlers/ping"
+Dir[File.expand_path("../dude/handlers/*.rb", __FILE__)].each { |file| require file }

--- a/lib/dude/handlers/deploy.rb
+++ b/lib/dude/handlers/deploy.rb
@@ -5,10 +5,10 @@ class Dude::Handlers::Deploy < Lita::Handler
     repo_name, branch, env = extract_repo_branch_and_env(response.matches.first)
     repo = Dude::Repo.new(repo_name: repo_name, branch: branch)
 
-    unless repo.deployable?
-      response.reply("Oops! I can't deploy #{repo_name}/#{branch} (#{repo.sha}). CI still running?")
-      return
-    end
+    # unless repo.deployable?
+      # response.reply("Oops! I can't deploy #{repo_name}/#{branch} (#{repo.sha}). CI still running?")
+      # return
+    # end
 
     response.reply("deploying #{repo_name}/#{branch} (#{repo.sha}) to #{env}")
     repo.deploy

--- a/lib/dude/handlers/deploy.rb
+++ b/lib/dude/handlers/deploy.rb
@@ -1,0 +1,20 @@
+class Dude::Handlers::Deploy < Lita::Handler
+  route(%r{\Adeploy ([^\s\/]+(\/[^\s\/]+)?) to (staging|production)\z}, :deploy, command: true)
+
+  def deploy(response)
+    repo, branch, env = extract_repo_branch_and_env(response.matches.first)
+    response.reply("deploying #{repo} (#{branch}) to #{env}")
+  end
+
+  private
+
+  def extract_repo_branch_and_env(match)
+    repo, branch, env = match
+    repo = repo.split("/").first unless branch.nil?
+    branch ||= "/master"
+
+    [repo, branch[1..-1], env]
+  end
+end
+
+Lita.register_handler(Dude::Handlers::Deploy)

--- a/lib/dude/handlers/deploy.rb
+++ b/lib/dude/handlers/deploy.rb
@@ -2,8 +2,16 @@ class Dude::Handlers::Deploy < Lita::Handler
   route(%r{\Adeploy ([^\s\/]+(\/[^\s\/]+)?) to (staging|production)\z}, :deploy, command: true)
 
   def deploy(response)
-    repo, branch, env = extract_repo_branch_and_env(response.matches.first)
-    response.reply("deploying #{repo} (#{branch}) to #{env}")
+    repo_name, branch, env = extract_repo_branch_and_env(response.matches.first)
+    repo = Dude::Repo.new(repo_name: repo_name, branch: branch)
+
+    unless repo.deployable?
+      response.reply("Oops! I can't deploy #{repo_name}/#{branch} (#{repo.sha}). CI still running?")
+      return
+    end
+
+    response.reply("deploying #{repo_name}/#{branch} (#{repo.sha}) to #{env}")
+    repo.deploy
   end
 
   private

--- a/lib/dude/repo.rb
+++ b/lib/dude/repo.rb
@@ -1,0 +1,16 @@
+class Dude::Repo
+  attr_reader :repo_name, :branch
+
+  def initialize(repo_name:, branch: "master")
+    @repo_name = repo_name
+    @branch    = branch
+  end
+
+  def https_url
+    @https_url ||= "https://github.com/sweeperio/#{repo_name}.git"
+  end
+
+  def ssh_url
+    @ssh_url ||= "git@github.com:sweeperio/#{repo_name}.git"
+  end
+end

--- a/lib/dude/repo.rb
+++ b/lib/dude/repo.rb
@@ -1,4 +1,6 @@
 class Dude::Repo
+  OWNER = "sweeperio".freeze
+
   attr_reader :repo_name, :branch
 
   def initialize(repo_name:, branch: "master")
@@ -7,10 +9,21 @@ class Dude::Repo
   end
 
   def https_url
-    @https_url ||= "https://github.com/sweeperio/#{repo_name}.git"
+    @https_url ||= "https://github.com/#{OWNER}/#{repo_name}.git"
   end
 
   def ssh_url
-    @ssh_url ||= "git@github.com:sweeperio/#{repo_name}.git"
+    @ssh_url ||= "git@github.com:#{OWNER}/#{repo_name}.git"
+  end
+
+  def status
+    @status ||= begin
+      client = Octokit::Client.new(access_token: Settings.get(:octokit, :token))
+      client.status("#{OWNER}/#{repo_name}", branch)
+    end
+  end
+
+  def deployable?
+    status.state == "success"
   end
 end

--- a/lib/dude/repo.rb
+++ b/lib/dude/repo.rb
@@ -8,6 +8,9 @@ class Dude::Repo
     @branch    = branch
   end
 
+  def deploy
+  end
+
   def https_url
     @https_url ||= "https://github.com/#{OWNER}/#{repo_name}.git"
   end
@@ -21,6 +24,10 @@ class Dude::Repo
       client = Octokit::Client.new(access_token: Settings.get(:octokit, :token))
       client.status("#{OWNER}/#{repo_name}", branch)
     end
+  end
+
+  def sha
+    @sha ||= `git rev-parse --short #{status.sha}`.chomp
   end
 
   def deployable?

--- a/lib/dude/repo.rb
+++ b/lib/dude/repo.rb
@@ -12,12 +12,13 @@ class Dude::Repo
     @ssh_url   = "git@github.com:#{full_name}.git"
   end
 
-  def deploy(env: "production")
+  def deploy(user:, env: "production")
     api.create_deployment(
       full_name,
       branch,
       auto_merge: false,
       environment: env,
+      payload: JSON.generate(deploy_user: user, environment: env),
       description: "deploy triggered by dude"
     )
   end
@@ -28,10 +29,6 @@ class Dude::Repo
 
   def sha
     @sha ||= `git rev-parse --short #{status.sha}`.chomp
-  end
-
-  def deployable?
-    status.state == "success"
   end
 
   private

--- a/lib/settings.rb
+++ b/lib/settings.rb
@@ -6,7 +6,7 @@ class Settings
       names.inject(settings) { |config, key| config.fetch(key) }
     end
 
-    def configure_lita(config, values: settings)
+    def configure_lita(config, values: settings[:lita])
       values.each do |key, value|
         if value.is_a?(Hash)
           configure_lita(config.public_send(key), values: value)
@@ -28,7 +28,7 @@ class Settings
                    end
 
         settings = (settings[env] || {}).with_indifferent_access
-        settings.deep_merge(Secrets[:lita])
+        settings.deep_merge(Secrets)
       end
     end
 

--- a/lita_config.rb
+++ b/lita_config.rb
@@ -1,6 +1,7 @@
 require "bundler"
 Bundler.require
 
+require "octokit"
 Dir[File.expand_path("../lib/*.rb", __FILE__)].each { |file| require file }
 
 Lita.configure do |config|

--- a/spec/files/status_stub.json
+++ b/spec/files/status_stub.json
@@ -1,0 +1,58 @@
+{
+  "state": "success",
+  "sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e",
+  "total_count": 2,
+  "statuses": [
+    {
+      "created_at": "2012-07-20T01:19:13Z",
+      "updated_at": "2012-07-20T01:19:13Z",
+      "state": "success",
+      "target_url": "https://ci.example.com/1000/output",
+      "description": "Build has completed successfully",
+      "id": 1,
+      "url": "https://api.github.com/repos/octocat/Hello-World/statuses/1",
+      "context": "continuous-integration/jenkins"
+    },
+    {
+      "created_at": "2012-08-20T01:19:13Z",
+      "updated_at": "2012-08-20T01:19:13Z",
+      "state": "success",
+      "target_url": "https://ci.example.com/2000/output",
+      "description": "Testing has completed successfully",
+      "id": 2,
+      "url": "https://api.github.com/repos/octocat/Hello-World/statuses/2",
+      "context": "security/brakeman"
+    }
+  ],
+  "repository": {
+    "id": 1296269,
+    "owner": {
+      "login": "octocat",
+      "id": 1,
+      "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/octocat",
+      "html_url": "https://github.com/octocat",
+      "followers_url": "https://api.github.com/users/octocat/followers",
+      "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+      "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+      "organizations_url": "https://api.github.com/users/octocat/orgs",
+      "repos_url": "https://api.github.com/users/octocat/repos",
+      "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/octocat/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "name": "Hello-World",
+    "full_name": "octocat/Hello-World",
+    "description": "This your first repo!",
+    "private": false,
+    "fork": false,
+    "url": "https://api.github.com/repos/octocat/Hello-World",
+    "html_url": "https://github.com/octocat/Hello-World"
+  },
+  "commit_url": "https://api.github.com/repos/octocat/Hello-World/6dcb09b5b57875f334f61aebed695e2e4193db5e",
+  "url": "https://api.github.com/repos/octocat/Hello-World/6dcb09b5b57875f334f61aebed695e2e4193db5e/status"
+}

--- a/spec/lib/dude/handlers/deploy_spec.rb
+++ b/spec/lib/dude/handlers/deploy_spec.rb
@@ -42,9 +42,12 @@ describe Dude::Handlers::Deploy, lita_handler: true do
     end
 
     it "doesn't trigger the deploy if the target is not deployable (failed CI, etc)" do
-      expect_any_instance_of(Dude::Repo).to receive(:deployable?).and_return(false)
+      error = Octokit::Conflict.new(nil)
+      expect(error).to receive(:errors).and_return([{ contexts: [] }])
+      expect_any_instance_of(Octokit::Client).to receive(:create_deployment).and_raise(error)
+
       send_command("deploy dude to production")
-      expect(replies).to include("Oops! I can't deploy dude/master (6dcb09b). CI still running?")
+      expect(replies).to include("*ERROR DEPLOYING 6dcb09b to production*")
     end
 
     it "triggers a deploy on the repo" do

--- a/spec/lib/dude/handlers/deploy_spec.rb
+++ b/spec/lib/dude/handlers/deploy_spec.rb
@@ -1,0 +1,32 @@
+require "spec_helper"
+
+describe Dude::Handlers::Deploy, lita_handler: true do
+  context "#deploy" do
+    [
+      "deploy dude to staging",
+      "deploy dude/master to production",
+      "deploy dude/some-branch to production"
+    ].each do |command|
+      it { is_expected.to route_command(command).to(:deploy) }
+    end
+
+    [
+      "deploy to production",
+      "deploy dude/master to badenv",
+      "deploy dude production",
+      "deploy dude/test/branch-name to staging"
+    ].each do |command|
+      it { is_expected.to_not route_command(command) }
+    end
+
+    it "extracts repo name and environment from the command" do
+      send_command("deploy dude to production")
+      expect(replies).to include("deploying dude (master) to production")
+    end
+
+    it "extracts repo name, branch name and environment from the command" do
+      send_command("deploy dude/my-feature-branch to production")
+      expect(replies).to include("deploying dude (my-feature-branch) to production")
+    end
+  end
+end

--- a/spec/lib/dude/handlers/deploy_spec.rb
+++ b/spec/lib/dude/handlers/deploy_spec.rb
@@ -10,6 +10,10 @@ describe Dude::Handlers::Deploy, lita_handler: true do
   end
 
   context "#deploy" do
+    before do
+      allow_any_instance_of(Octokit::Client).to receive(:create_deployment)
+    end
+
     [
       "deploy dude to staging",
       "deploy dude/master to production",

--- a/spec/lib/dude/handlers/deploy_spec.rb
+++ b/spec/lib/dude/handlers/deploy_spec.rb
@@ -1,6 +1,14 @@
 require "spec_helper"
 
 describe Dude::Handlers::Deploy, lita_handler: true do
+  before do
+    stub_request(:get, %r{https://api.github.com/repos/sweeperio/dude/commits/.*/status}).to_return(
+      status: 200,
+      body: fixture_file("status_stub.json"),
+      headers: { "Content-Type" => "application/json" }
+    )
+  end
+
   context "#deploy" do
     [
       "deploy dude to staging",
@@ -21,12 +29,23 @@ describe Dude::Handlers::Deploy, lita_handler: true do
 
     it "extracts repo name and environment from the command" do
       send_command("deploy dude to production")
-      expect(replies).to include("deploying dude (master) to production")
+      expect(replies).to include("deploying dude/master (6dcb09b) to production")
     end
 
     it "extracts repo name, branch name and environment from the command" do
       send_command("deploy dude/my-feature-branch to production")
-      expect(replies).to include("deploying dude (my-feature-branch) to production")
+      expect(replies).to include("deploying dude/my-feature-branch (6dcb09b) to production")
+    end
+
+    it "doesn't trigger the deploy if the target is not deployable (failed CI, etc)" do
+      expect_any_instance_of(Dude::Repo).to receive(:deployable?).and_return(false)
+      send_command("deploy dude to production")
+      expect(replies).to include("Oops! I can't deploy dude/master (6dcb09b). CI still running?")
+    end
+
+    it "triggers a deploy on the repo" do
+      expect_any_instance_of(Dude::Repo).to receive(:deploy)
+      send_command("deploy dude to production")
     end
   end
 end

--- a/spec/lib/dude/repo_spec.rb
+++ b/spec/lib/dude/repo_spec.rb
@@ -15,6 +15,10 @@ describe Dude::Repo do
     expect(Dude::Repo.new(repo_name: "dude").branch).to eq("master")
   end
 
+  it "sets full_name to the full repo name" do
+    expect(subject.full_name).to eq("sweeperio/dude")
+  end
+
   it "sets https_url appropriately" do
     expect(subject.https_url).to eq("https://github.com/sweeperio/dude.git")
   end
@@ -35,6 +39,20 @@ describe Dude::Repo do
     it "is false when the state is not success" do
       expect(subject.status).to receive(:state).and_return("failed")
       expect(subject.deployable?).to_not be true
+    end
+  end
+
+  context "#deploy" do
+    it "creates a deployment on GitHub" do
+      expect_any_instance_of(Octokit::Client).to receive(:create_deployment).with(
+        "sweeperio/dude",
+        "master",
+        auto_merge: false,
+        environment: "production",
+        description: "deploy triggered by dude"
+      )
+
+      subject.deploy
     end
   end
 end

--- a/spec/lib/dude/repo_spec.rb
+++ b/spec/lib/dude/repo_spec.rb
@@ -1,0 +1,17 @@
+require "spec_helper"
+
+describe Dude::Repo do
+  subject { Dude::Repo.new(repo_name: "dude", branch: "master") }
+
+  it "defaults branch to master" do
+    expect(Dude::Repo.new(repo_name: "dude").branch).to eq("master")
+  end
+
+  it "sets https_url appropriately" do
+    expect(subject.https_url).to eq("https://github.com/sweeperio/dude.git")
+  end
+
+  it "sets ssh_url appropriately" do
+    expect(subject.ssh_url).to eq("git@github.com:sweeperio/dude.git")
+  end
+end

--- a/spec/lib/dude/repo_spec.rb
+++ b/spec/lib/dude/repo_spec.rb
@@ -3,6 +3,14 @@ require "spec_helper"
 describe Dude::Repo do
   subject { Dude::Repo.new(repo_name: "dude", branch: "master") }
 
+  before do
+    stub_request(:get, "https://api.github.com/repos/sweeperio/dude/commits/master/status").to_return(
+      status: 200,
+      body: fixture_file("status_stub.json"),
+      headers: { "Content-Type" => "application/json" }
+    )
+  end
+
   it "defaults branch to master" do
     expect(Dude::Repo.new(repo_name: "dude").branch).to eq("master")
   end
@@ -13,5 +21,20 @@ describe Dude::Repo do
 
   it "sets ssh_url appropriately" do
     expect(subject.ssh_url).to eq("git@github.com:sweeperio/dude.git")
+  end
+
+  it "fetches status from GitHub" do
+    expect(subject.status.state).to eq("success")
+  end
+
+  context "#deployable?" do
+    it "is true when the state is success" do
+      expect(subject.deployable?).to be true
+    end
+
+    it "is false when the state is not success" do
+      expect(subject.status).to receive(:state).and_return("failed")
+      expect(subject.deployable?).to_not be true
+    end
   end
 end

--- a/spec/lib/dude/repo_spec.rb
+++ b/spec/lib/dude/repo_spec.rb
@@ -31,17 +31,6 @@ describe Dude::Repo do
     expect(subject.status.state).to eq("success")
   end
 
-  context "#deployable?" do
-    it "is true when the state is success" do
-      expect(subject.deployable?).to be true
-    end
-
-    it "is false when the state is not success" do
-      expect(subject.status).to receive(:state).and_return("failed")
-      expect(subject.deployable?).to_not be true
-    end
-  end
-
   context "#deploy" do
     it "creates a deployment on GitHub" do
       expect_any_instance_of(Octokit::Client).to receive(:create_deployment).with(
@@ -49,10 +38,11 @@ describe Dude::Repo do
         "master",
         auto_merge: false,
         environment: "production",
+        payload: JSON.generate(deploy_user: "pseudomuto", environment: "production"),
         description: "deploy triggered by dude"
       )
 
-      subject.deploy
+      subject.deploy(user: "pseudomuto")
     end
   end
 end

--- a/spec/lib/settings_spec.rb
+++ b/spec/lib/settings_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Settings do
   subject do
     Class.new do
-      attr_accessor :name, :robot, :secret
+      attr_accessor :robot, :secret
 
       def initialize
         @robot = OpenStruct.new(name: nil)
@@ -13,12 +13,8 @@ RSpec.describe Settings do
     before(:each) { Settings.configure_lita(config) }
     let(:config)  { subject.new }
 
-    it "assigns values to simple properties" do
-      expect(config.name).to eq("test")
-    end
-
     it "assigns attributes to children" do
-      expect(config.robot.name).to eq("dude")
+      expect(config.robot.name).to eq("test")
     end
 
     it "assigns attributes from Secrets[:lita] as well" do
@@ -28,11 +24,11 @@ RSpec.describe Settings do
 
   context ".get" do
     it "returns the setting value" do
-      expect(Settings.get(:name)).to eq("test")
+      expect(Settings.get(:lita, :secret)).to eq("known")
     end
 
     it "returns nested settings" do
-      expect(Settings.get(:robot, :name)).to eq("dude")
+      expect(Settings.get(:lita, :robot, :name)).to eq("test")
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 ENV["ENV"] = "test"
 
 require "lita/rspec"
+require "webmock/rspec"
 require "pry-byebug"
 require File.expand_path("../../lita_config", __FILE__)
 
@@ -18,4 +19,8 @@ RSpec.configure do |config|
   config.mock_with :rspec do |mocks|
     mocks.verify_partial_doubles = true
   end
+end
+
+def fixture_file(path)
+  IO.binread(File.expand_path("../files/#{path}", __FILE__))
 end


### PR DESCRIPTION
# The Problem

I want to be able to use Slack to deploy applications. To do this, I'm going to have dude create a deployment in GitHub and have that trigger a deploy via normal deploy hook.
# The Solution

This is the first part of the solution. Dude will now respond to the following commands (must be prefixed with `dude`).
- `deploy [app] to production`
- `deploy [app]/[branch] to production`

If not specified, branch will default to `master`. Also, currently I only have production applications, but `staging` is also a valid option.

Once triggered, the status of the branch is checked (CI, etc). If it's valid, a deploy is created via the API. If not a message is shown explaining that the deploy could not be created
